### PR TITLE
Relax dependencies to work with ghc-7.6.3

### DIFF
--- a/hreddit.cabal
+++ b/hreddit.cabal
@@ -10,6 +10,7 @@ maintainer:          rodrigosetti@gmail.com
 copyright:           2013 Rodrigo Setti
 category:            Web
 build-type:          Simple
+tested-with:         GHC == 7.6.3
 cabal-version:       >=1.8
 exposed-modules:     System.Console.CommandLoop,
                      Network.Reddit,
@@ -20,11 +21,11 @@ executable hreddit
   ghc-options:       -Wall
   hs-source-dirs:    src
   main-is:           Main.hs
-  build-depends:     base ==4.5.*,
+  build-depends:     base >=4.5 && < 5,
                      readline ==1.*,
                      mtl ==2.*,
                      network==2.*,
                      HTTP==4000.2.*,
-                     bytestring==0.9.*,
+                     bytestring >=0.9 && < 0.11,
                      aeson==0.6.*
 


### PR DESCRIPTION
Relaxed dependencies for base and bytestring packages, for ghc-7.6 compatibility. bytestring-0.10.0.2 and base-4.6.0.1 are bundled with ghc-7.6.3. A `tested-with` field has also been added.
